### PR TITLE
Add `aeon` conda recipe.

### DIFF
--- a/aeon/build.sh
+++ b/aeon/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# -e = exit on first error
+# -x = print every executed command
+set -ex
+
+# Use a custom temporary directory as home on macOS.
+# (not sure why this is useful, but people use it in bioconda recipes)
+if [ `uname` == Darwin ]; then
+  export HOME=`mktemp -d`
+fi
+
+# Build the package using maturin - should produce *.whl files.
+maturin build --interpreter python --release
+
+# Install *.whl files using pip
+$PYTHON -m pip install target/wheels/*.whl --no-deps --ignore-installed -vv

--- a/aeon/meta.yaml
+++ b/aeon/meta.yaml
@@ -1,0 +1,32 @@
+{% set name = "aeon" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://github.com/sybila/biodivine-aeon-py/archive/refs/tags/{{ version }}.tar.gz"
+  sha256: "e7ddfb39bb7f22cabcde8385222532e7b5f1d1c1927b130cf45dbab33123f6d9"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - pip
+    - rust
+    - maturin
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - biodivine_aeon
+
+about:
+  home: https://github.com/sybila/biodivine-aeon-py
+  license: MIT License
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Python/Rust library for symbolic manipulation of Boolean networks."


### PR DESCRIPTION
Add a recipe for `biodivine_aeon`, a Python library bindings for [AEON](http://biodivine.fi.muni.cz/aeon). 

The tool is based on `PyO3` and `maturin` rust-python bindings. The recipe is based on a similar maturin-based recipe available through bioconda for some other tool. It builds fine on my macOS machine, so hopefully should be ok.